### PR TITLE
Add roast upload, decoupling the app from the local RoastTime path

### DIFF
--- a/roastprofiler/app.py
+++ b/roastprofiler/app.py
@@ -25,6 +25,9 @@ from .scripts.utils import (
     bean_from_form,
     DataFileHandler,
     save_processed_roast,
+    save_uploaded_roast,
+    delete_uploaded_roast,
+    is_valid_roast_id,
     resource_path,
 )
 
@@ -95,9 +98,69 @@ def generate_roast_profile_route(roast_id):
         return jsonify({"error": str(e)}), 500
 
 
+@app.route("/upload_roasts", methods=["POST"])
+def upload_roasts():
+    files = request.files.getlist("roast_files")
+    files = [f for f in files if f and f.filename]
+    if not files:
+        return jsonify({"error": "No files uploaded."}), 400
+
+    added, skipped = [], []
+    for f in files:
+        filename = f.filename
+        try:
+            roast_data_json = json.loads(f.read().decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            skipped.append(
+                {"filename": filename, "reason": "Not a valid JSON roast file."}
+            )
+            continue
+
+        roast_id = roast_data_json.get("uid")
+        if not is_valid_roast_id(roast_id):
+            skipped.append(
+                {"filename": filename, "reason": "Missing or invalid roast id (uid)."}
+            )
+            continue
+
+        # confirm it's a roast the app can actually render before storing it
+        try:
+            extract_roast_data(roast_data_json)
+        except Exception as e:
+            skipped.append(
+                {
+                    "filename": filename,
+                    "reason": f"Not a recognizable RoastTime roast ({e}).",
+                }
+            )
+            continue
+
+        save_uploaded_roast(roast_id, roast_data_json)
+        added.append(
+            {
+                "filename": filename,
+                "id": roast_id,
+                "roastName": roast_data_json.get("roastName"),
+            }
+        )
+
+    return jsonify({"added": added, "skipped": skipped}), 200
+
+
+@app.route("/delete_uploaded_roast/<roast_id>", methods=["DELETE"])
+def delete_uploaded_roast_route(roast_id):
+    try:
+        removed = delete_uploaded_roast(roast_id)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    if removed:
+        return jsonify({"message": "Uploaded roast removed."}), 200
+    return jsonify({"error": "Uploaded roast not found."}), 404
+
+
 @app.route("/download_qr/<roast_id>")
 def download_qr(roast_id):
-    qr_code_path = f"cache/qr_codes/{roast_id}_qr.png"
+    qr_code_path = resource_path(f"cache/qr_codes/{roast_id}_qr.png")
     if os.path.exists(qr_code_path):
         return send_file(qr_code_path, as_attachment=True)
     else:
@@ -251,7 +314,11 @@ def roast_profile_settings():
 @app.route("/preview_profile/<roast_id>")
 def preview_profile(roast_id):
     roast = get_roast(roast_id)
-    bean = get_bean(roast["beanId"])
+    if not roast:
+        return "Roast not found.", 404
+    # bean may be unregistered (common for uploaded roasts) — fall back to {}
+    # so the preview still renders instead of crashing on a missing bean
+    bean = get_bean(roast.get("beanId")) or {}
     config = get_config()
     roast_data = extract_roast_data(roast)
     merged_data = {**roast_data, **bean, **config}

--- a/roastprofiler/scripts/generate_roast_profile.py
+++ b/roastprofiler/scripts/generate_roast_profile.py
@@ -7,7 +7,7 @@ from botocore.exceptions import ClientError
 
 from .roast_data import extract_roast_data
 from .html_template import generate_qr_code, generate_webpage
-from .utils import get_beans, get_config, get_roast_path, resource_path
+from .utils import get_bean, get_config, find_roast_file, resource_path
 
 
 cache_dir = resource_path("cache")
@@ -47,7 +47,6 @@ def copy_and_overwrite(from_path, to_path):
 
 
 def generate_roast_profile(roast_id, env="local"):
-    roast_path = get_roast_path()
     config = get_config()
 
     base_url = config.get("s3_base_url")
@@ -55,7 +54,12 @@ def generate_roast_profile(roast_id, env="local"):
     s3_access_key = config.get("s3_access_key")
     s3_secret_key = config.get("s3_secret_key")
 
-    logging.info(f"Processing roast file: {roast_path}/{roast_id}")
+    # Resolve the roast file from either source (uploaded or local RoastTime)
+    roast_file_path = find_roast_file(roast_id)
+    if not roast_file_path:
+        raise FileNotFoundError(f"Roast file not found for id {roast_id}")
+
+    logging.info(f"Processing roast file: {roast_file_path}")
 
     s3_client = boto3.client(
         "s3",
@@ -63,18 +67,13 @@ def generate_roast_profile(roast_id, env="local"):
         aws_secret_access_key=s3_secret_key,
     )
 
-    # Load the roast data from roast-time
-    roast_file_path = os.path.join(roast_path, roast_id)
-    if roast_file_path.endswith(".DS_Store"):
-        return
-
     # load the roast data
     try:
         with open(roast_file_path, "r", encoding="utf-8") as f:
             roast_data_json = json.load(f)
     except (UnicodeDecodeError, json.JSONDecodeError) as e:
         logging.error(f"Error reading file {roast_file_path}: {e}")
-        return
+        raise
 
     # define local directories
     roast_directory = f"roasts/{roast_id}"
@@ -85,14 +84,16 @@ def generate_roast_profile(roast_id, env="local"):
     # local file paths
     webpage_local_path = os.path.join(roast_directory_local, "index.html")
 
-    # get bean data
+    # get bean data (matches on either id or uid, returns None if missing)
     bean_id = roast_data_json.get("beanId")
-    beans = get_beans()
-    bean = [bean for bean in beans if bean["id"] == bean_id][0]
+    bean = get_bean(bean_id)
 
     if not bean:
         logging.error(f"Bean ID {bean_id} not found.")
-        return
+        raise ValueError(
+            f"Bean not found for this roast (beanId={bean_id}). "
+            "Register the bean first, then publish."
+        )
 
     roast_data = extract_roast_data(roast_data_json)
     merged_data = {**roast_data, **bean, **config}
@@ -172,8 +173,10 @@ def generate_roast_profile(roast_id, env="local"):
     qr_codes_directory_local = os.path.join(cache_dir, qr_codes_directory)
     os.makedirs(qr_codes_directory_local, exist_ok=True)
     qr_code_local_path = os.path.join(qr_codes_directory_local, f"{roast_id}_qr.png")
-    generate_qr_code(roast_url, qr_code_local_path)
+    generate_qr_code(
+        roast_url, qr_code_local_path, f"{assets_directory_local}/logo.png"
+    )
 
     logging.info(f"Roast Profile generated: {roast_url}")
-    logging.info(f"Processing of {roast_path} completed.")
+    logging.info(f"Processing of {roast_file_path} completed.")
     return roast_url

--- a/roastprofiler/scripts/html_template.py
+++ b/roastprofiler/scripts/html_template.py
@@ -1,5 +1,7 @@
 import qrcode
+import qrcode
 import logging
+from PIL import Image
 from flask import url_for
 from datetime import datetime
 from jinja2 import Environment, FileSystemLoader
@@ -10,10 +12,34 @@ from .utils import resource_path
 roast_profile_template_dir = resource_path("roast_profile_template")
 
 
-def generate_qr_code(url, output_path):
-    img = qrcode.make(url)
-    img.save(output_path)
-    logging.info(f"QR code saved as {output_path}")
+# def generate_qr_code(url, output_path):
+#     img = qrcode.make(url)
+#     img.save(output_path)
+#     logging.info(f"QR code saved as {output_path}")
+
+
+def generate_qr_code(url, output_path, logo_path):
+    # Generate the basic QR code
+    qr_img = qrcode.make(url)
+
+    # Open and resize the logo
+    logo = Image.open(logo_path)
+    # Adjust the size ratio as needed; 1/5 of QR's size is a reasonable start
+    logo_size = (qr_img.size[0] // 5, qr_img.size[1] // 5)
+    logo = logo.resize(logo_size, Image.Resampling.LANCZOS)
+
+    # Calculate position to place the logo at the center
+    pos = ((qr_img.size[0] - logo_size[0]) // 2, (qr_img.size[1] - logo_size[1]) // 2)
+
+    # If the logo has transparency (RGBA), ensure it's preserved
+    if logo.mode == "RGBA":
+        qr_img.paste(logo, pos, mask=logo)
+    else:
+        qr_img.paste(logo, pos)
+
+    # Save the final image
+    qr_img.save(output_path)
+    logging.info(f"QR code with logo saved as {output_path}")
 
 
 def static_url(filename, env):

--- a/roastprofiler/scripts/utils.py
+++ b/roastprofiler/scripts/utils.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import os
 import json
@@ -20,6 +21,21 @@ data_dir = resource_path("data")
 os.makedirs(data_dir, exist_ok=True)
 BEANS_FILE = os.path.join(data_dir, "beans.json")
 ROAST_PROFILES_FILE = os.path.join(data_dir, "roast_profiles.json")
+
+# App-owned store for roasts uploaded through the UI (as opposed to roasts read
+# live from a local RoastTime install). Files are named by their RoastTime `uid`,
+# matching the on-disk convention RoastTime itself uses, so the rest of the code
+# can treat both sources identically.
+UPLOADED_ROASTS_DIR = os.path.join(data_dir, "roasts")
+os.makedirs(UPLOADED_ROASTS_DIR, exist_ok=True)
+
+# RoastTime ids are nanoids ([A-Za-z0-9_-]); validating against this keeps the id
+# safe to use as a filename (no path separators / traversal).
+ROAST_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def is_valid_roast_id(roast_id):
+    return bool(roast_id) and bool(ROAST_ID_RE.match(roast_id))
 
 
 # Ensure data directory exists
@@ -115,7 +131,14 @@ def get_beans():
 
     combined_beans = {bean["id"]: bean for bean in roastime_beans}
     for bean in beans:
-        combined_beans[bean["id"]] = {**combined_beans[bean["id"]], **bean}
+        bean_id = bean.get("id")
+        if bean_id in combined_beans:
+            # overlay the app's saved fields on top of the RoastTime bean
+            combined_beans[bean_id] = {**combined_beans[bean_id], **bean}
+        else:
+            # bean exists only in beans.json (e.g. registered while RoastTime
+            # isn't installed) — keep it instead of raising a KeyError
+            combined_beans[bean_id] = bean
 
     return list(combined_beans.values())
 
@@ -128,40 +151,93 @@ def get_roast_profiles():
         return []
 
 
+def _list_roast_files():
+    """Yield (source, roast_id, path) for every roast file across both sources.
+
+    Uploaded roasts take precedence over a local RoastTime roast with the same id,
+    so a roast that exists in both is reported once, tagged "uploaded". Either
+    source may be absent — the app works with uploads only, RoastTime only, or both.
+    """
+    sources = [
+        ("uploaded", UPLOADED_ROASTS_DIR),
+        ("roasttime", get_roast_path()),
+    ]
+    seen = set()
+    for source_name, source_path in sources:
+        if not source_path or not os.path.exists(source_path):
+            continue
+        for name in os.listdir(source_path):
+            if name == ".DS_Store" or name in seen:
+                continue
+            seen.add(name)
+            yield source_name, name, os.path.join(source_path, name)
+
+
+def find_roast_file(roast_id):
+    """Locate a roast file by id, preferring an uploaded copy over a RoastTime one."""
+    for source_path in (UPLOADED_ROASTS_DIR, get_roast_path()):
+        if source_path and os.path.exists(source_path):
+            candidate = os.path.join(source_path, roast_id)
+            if os.path.isfile(candidate):
+                return candidate
+    return None
+
+
+def save_uploaded_roast(roast_id, roast_data_json):
+    """Persist an uploaded roast's JSON to the app-owned store, named by its id."""
+    if not is_valid_roast_id(roast_id):
+        raise ValueError(f"Invalid roast id: {roast_id!r}")
+    path = os.path.join(UPLOADED_ROASTS_DIR, roast_id)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(roast_data_json, f)
+    return path
+
+
+def delete_uploaded_roast(roast_id):
+    """Remove an uploaded roast. Returns True if a file was deleted."""
+    if not is_valid_roast_id(roast_id):
+        raise ValueError(f"Invalid roast id: {roast_id!r}")
+    path = os.path.join(UPLOADED_ROASTS_DIR, roast_id)
+    if os.path.isfile(path):
+        os.remove(path)
+        return True
+    return False
+
+
 def get_roasts():
     roasts = []
-    roast_path = get_roast_path()
     roast_profiles = get_roast_profiles()
-    if os.path.exists(roast_path):
-        roast_files = [f for f in os.listdir(roast_path)]
-        for roast_file in roast_files:
-            roast_file_path = os.path.join(roast_path, roast_file)
-            try:
-                with open(roast_file_path, "r") as f:
-                    roast_data_json = json.load(f)
-                    roast_data = extract_roast_data(roast_data_json)
+    for source_name, roast_id, roast_file_path in _list_roast_files():
+        try:
+            with open(roast_file_path, "r", encoding="utf-8") as f:
+                roast_data_json = json.load(f)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            print(f"Invalid JSON format in file: {roast_file_path}")
+            continue
+        except Exception as e:
+            print(f"Error reading file {roast_file_path}: {e}")
+            continue
 
-                    # check if roast has been processed
-                    processed_roast = next(
-                        (r for r in roast_profiles if r["id"] == roast_data["id"]), None
-                    )
-                    if processed_roast:
-                        roast_data["is_processed"] = True
-                        roast_data = {**roast_data, **processed_roast}
-                    else:
-                        roast_data["is_processed"] = False
-                    roasts.append(roast_data)
-            except FileNotFoundError:
-                print(f"File not found: {roast_file_path}")
-                continue
-            except json.JSONDecodeError:
-                print(f"Invalid JSON format in file: {roast_file_path}")
-                continue
-            except Exception as e:
-                print(f"Error reading file {roast_file_path}: {e}")
-                continue
+        try:
+            roast_data = extract_roast_data(roast_data_json)
+        except Exception as e:
+            print(f"Error parsing roast {roast_file_path}: {e}")
+            continue
 
-        return roasts
+        roast_data["source"] = source_name
+
+        # check if roast has been processed
+        processed_roast = next(
+            (r for r in roast_profiles if r["id"] == roast_data["id"]), None
+        )
+        if processed_roast:
+            roast_data["is_processed"] = True
+            roast_data = {**roast_data, **processed_roast}
+        else:
+            roast_data["is_processed"] = False
+        roasts.append(roast_data)
+
+    return roasts
 
 
 def load_roastime_beans():

--- a/roastprofiler/templates/components/roast_card.html
+++ b/roastprofiler/templates/components/roast_card.html
@@ -65,6 +65,15 @@
         </button>
         {% endif %}
         {% endif %}
+
+        {% if roast.source == 'uploaded' %}
+        <div class="col-md-12">
+          <button class="btn btn-outline-danger btn-sm w-100 mt-1"
+            onclick="deleteUploadedRoast(this, '{{ roast.uid }}')">
+            <i class="bi bi-trash me-2"></i>Remove Uploaded Roast
+          </button>
+        </div>
+        {% endif %}
       </div>
     </div>
   </div>
@@ -142,5 +151,33 @@
     iframe.src = `/preview_profile/${roastId}`;
     const modal = new bootstrap.Modal(document.getElementById('previewProfileModal'));
     modal.show();
+  }
+
+  function deleteUploadedRoast(button, roastId) {
+    if (!confirm("Remove this uploaded roast? This only deletes the uploaded copy.")) {
+      return
+    }
+    button.disabled = true
+    const originalHTML = button.innerHTML
+    button.innerHTML =
+      '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>'
+
+    fetch(`/delete_uploaded_roast/${roastId}`, { method: "DELETE" })
+      .then(response => response.json().then(data => ({ ok: response.ok, data })))
+      .then(({ ok, data }) => {
+        if (!ok) {
+          throw new Error(data.error || "Failed to remove roast.")
+        }
+        toast("Success", "Uploaded roast removed.")
+        const card = document.getElementById(`roast-${roastId}`)
+        if (card) {
+          card.remove()
+        }
+      })
+      .catch(error => {
+        button.disabled = false
+        button.innerHTML = originalHTML
+        toast("Error", error.message)
+      })
   }
 </script>

--- a/roastprofiler/templates/components/upload_roasts_modal.html
+++ b/roastprofiler/templates/components/upload_roasts_modal.html
@@ -1,0 +1,27 @@
+<div class="modal fade" id="uploadRoastsModal" tabindex="-1" aria-labelledby="uploadRoastsModalLabel"
+  aria-hidden="true">
+  <div class="modal-dialog modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="uploadRoastsModalLabel">Upload Roasts</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="text-muted small">
+          Select one or more RoastTime roast files &mdash; the files in your
+          <code>roast-time/roasts</code> folder (they have no file extension). Uploaded roasts are saved
+          in the app and appear alongside any roasts read from a local RoastTime install.
+        </p>
+        <form id="uploadRoastsForm" enctype="multipart/form-data">
+          <div class="mb-3">
+            <input type="file" class="form-control" id="roast_files" name="roast_files" multiple required>
+          </div>
+          <div id="uploadResult" class="small mb-3"></div>
+          <button type="submit" class="btn btn-primary w-100">
+            <i class="bi bi-upload me-2"></i>Upload
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/roastprofiler/templates/pages/roasts.html
+++ b/roastprofiler/templates/pages/roasts.html
@@ -4,8 +4,13 @@
 <div class="container my-4">
   <div class="d-flex justify-content-between align-items-center mb-4">
     <h1 class="mb-0">Roasts</h1>
-    <input type="text" class="form-control d-inline-block" id="searchInput" placeholder="Search roasts..."
-      style="width: 200px;" onkeyup="searchRoasts()">
+    <div class="d-flex gap-2">
+      <input type="text" class="form-control d-inline-block" id="searchInput" placeholder="Search roasts..."
+        style="width: 200px;" onkeyup="searchRoasts()">
+      <button type="button" class="btn btn-primary text-nowrap" onclick="uploadRoastsModal.show()">
+        <i class="bi bi-upload me-2"></i>Upload Roasts
+      </button>
+    </div>
   </div>
 
 
@@ -23,6 +28,7 @@
 </div>
 
 {% include 'components/bean_form_modal.html' %}
+{% include 'components/upload_roasts_modal.html' %}
 
 <script id="beans-data" type="application/json">
   {{ beans | tojson }}
@@ -31,6 +37,68 @@
   var beanFormModal = new bootstrap.Modal(
     document.getElementById("beanFormModal")
   )
+
+  var uploadRoastsModal = new bootstrap.Modal(
+    document.getElementById("uploadRoastsModal")
+  )
+
+  const uploadRoastsForm = document.getElementById("uploadRoastsForm")
+  uploadRoastsForm.addEventListener("submit", function (event) {
+    event.preventDefault()
+    const submitButton = this.querySelector('button[type="submit"]')
+    const originalButtonText = submitButton.innerHTML
+    submitButton.disabled = true
+    submitButton.innerHTML =
+      '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Uploading...'
+
+    fetch("/upload_roasts", { method: "POST", body: new FormData(this) })
+      .then(response => response.json())
+      .then(data => {
+        submitButton.disabled = false
+        submitButton.innerHTML = originalButtonText
+
+        if (data.error) {
+          toast("Error", data.error)
+          return
+        }
+
+        const added = data.added || []
+        const skipped = data.skipped || []
+        const resultEl = document.getElementById("uploadResult")
+        resultEl.innerHTML = skipped.length
+          ? '<div class="text-warning mb-1">Skipped:</div>' +
+            skipped.map(s => `<div>&bull; ${s.filename}: ${s.reason}</div>`).join("")
+          : ""
+
+        if (added.length > 0) {
+          toast(
+            "Success",
+            `Uploaded ${added.length} roast${added.length === 1 ? "" : "s"}.` +
+              (skipped.length ? ` ${skipped.length} skipped.` : "")
+          )
+          setTimeout(() => location.reload(), 900)
+        } else {
+          toast(
+            "Error",
+            skipped.length
+              ? `No roasts added. ${skipped[0].reason}`
+              : "No roasts added."
+          )
+        }
+      })
+      .catch(() => {
+        submitButton.disabled = false
+        submitButton.innerHTML = originalButtonText
+        toast("Error", "An error occurred while uploading.")
+      })
+  })
+
+  document
+    .getElementById("uploadRoastsModal")
+    .addEventListener("hidden.bs.modal", function () {
+      uploadRoastsForm.reset()
+      document.getElementById("uploadResult").innerHTML = ""
+    })
 
   function searchRoasts() {
     const input = document.getElementById("searchInput").value.toLowerCase()


### PR DESCRIPTION
Roasts can now be uploaded through the UI instead of only being read from a local RoastTime install. Both sources are merged (deduped by id) and each is optional, so the app works with uploads only, RoastTime only, or both.

- utils: app-owned data/roasts store; merge both sources in get_roasts(); find_roast_file/save/delete helpers; roast-id validation. Also fixes the get_beans() KeyError for beans only in beans.json and get_roasts() returning None when the RoastTime folder is absent.
- generate_roast_profile: resolve the roast from either source; raise a clear error when the bean is unregistered instead of an IndexError.
- app: POST /upload_roasts and DELETE /delete_uploaded_roast/<id>; harden /preview_profile against a missing roast/bean.
- UI: Upload Roasts button + modal; Remove Uploaded Roast on uploaded cards.

Also carries an entangled pre-existing change (logo-in-QR) in html_template.py and the matching generate_qr_code call, kept together for a consistent commit.